### PR TITLE
Fix "A non well formed numeric value encountered"

### DIFF
--- a/src/Mouf/Html/Widgets/FileUploaderWidget/JsFileUploader.php
+++ b/src/Mouf/Html/Widgets/FileUploaderWidget/JsFileUploader.php
@@ -46,6 +46,7 @@ class JsFileUploader {
     private function toBytes($str){
         $val = trim($str);
         $last = strtolower($str[strlen($str)-1]);
+        $val = (int) $val;
         switch($last) {
             case 'g': $val *= 1024;
             case 'm': $val *= 1024;


### PR DESCRIPTION
Casting `$val` to int (example : `"8M"` => `8`) to avoid PHP notice : "A non well formed numeric value encountered"